### PR TITLE
Do not mix output files that have the same prefix

### DIFF
--- a/test/ds_test_tools/core_test.clj
+++ b/test/ds_test_tools/core_test.clj
@@ -82,3 +82,19 @@
 
     (is (= [2 3 4 5] (sort output-incs)))
     (is (= [0 1 2 3] (sort output-decs)))))
+
+(deftest simple-pipeline-same-prefix
+  (let [job (fn [conf p]
+              (let [numbers (ds/read-edn-file (:numbers conf) p)
+                    decs (ds/map dec numbers)]
+                (ds/write-edn-file (tio/join-path (:output-originals conf)) numbers)
+                (ds/write-edn-file (tio/join-path (:output-decs conf)) decs)))
+        {:keys [output-originals output-decs]} (dtt/run-pipeline
+                                           {:use-outputs-map true}
+                                           {:numbers [1 2 3 4]}
+                                           {:output-originals "numbers"
+                                            :output-decs "numbers-decs"}
+                                           job)]
+
+    (is (= [1 2 3 4] (sort output-originals)))
+    (is (= [0 1 2 3] (sort output-decs)))))


### PR DESCRIPTION
without the fix you would have 
```clojure
(is (= [0 1 1 2 2 3 3 4 4 5] (sort output-originals)))
```